### PR TITLE
README.md add link to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Find your screenshots quickly with powerful search features:
 2. Install the APK on your Android device
 3. Follow the onboarding process to grant necessary permissions
 
+### Translation
+Please help to translate using [Weblate](https://toolate.othing.xyz/projects/pixelscreenshots/).
+
+<a href="https://toolate.othing.xyz/projects/pixelscreenshots/">
+<img src="https://toolate.othing.xyz/widget/pixelscreenshots/svg-badge.svg" alt="Translation status" />
+</a>
+
 ### Building from Source
 1. Clone the repository: `git clone https://github.com/AKS-Labs/PixelScreenshots.git`
 2. Open the project in Android Studio


### PR DESCRIPTION
To make it easier to translate it would be great to integrate a translation service.
The https://toolate.othing.xyz/ is an instance of the [Weblate](https://weblate.org/), it has no pre-moderation, it can send a PR with translations. It's used by many of the F-Droid apps.

I created a translation project on the Toolate https://toolate.othing.xyz/projects/pixelscreenshots/
and also made a testing translations and it sent you a PR #2.

If you are fine with the solution then please merge the PR that adds the Toolate link to the README to help users to find it. Also if you wish I can send you an invitation to become an admin of the translation project (needed sometimes to resolve merge conflicts).

Thank you for the app!